### PR TITLE
feat: more information in readme and consistent default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Follow the [instructions](https://cert-manager.io/docs/installation/) using the 
 #### Using public helm chart
 ```bash
 helm repo add cert-manager-webhook-hetzner https://vadimkim.github.io/cert-manager-webhook-hetzner
-helm install --namespace cert-manager cert-manager-webhook-hetzner cert-manager-webhook-hetzner/cert-manager-webhook-hetzner
+# Replace the groupName value with your desired domain
+helm install --namespace cert-manager cert-manager-webhook-hetzner cert-manager-webhook-hetzner/cert-manager-webhook-hetzner --set groupName=acme.yourdomain.tld
 ```
 
 #### From local checkout
@@ -57,7 +58,8 @@ spec:
     solvers:
       - dns01:
           webhook:
-            groupName: acme.yourdomain.here
+            # This group needs to be configured when installing the helm package, otherwise the webhook won't have permission to create an ACME challenge for this API group.
+            groupName: acme.yourdomain.tld
             solverName: hetzner
             config:
               secretName: hetzner-secret

--- a/deploy/cert-manager-webhook-hetzner/values.yaml
+++ b/deploy/cert-manager-webhook-hetzner/values.yaml
@@ -6,7 +6,7 @@
 # solve the DNS01 challenge.
 # This group name should be **unique**, hence using your own company's domain
 # here is recommended.FROM golang:1.14.0-alpine AS build_deps
-groupName: acme.unique.company.name
+groupName: acme.yourdomain.tld
 
 certManager:
   namespace: cert-manager


### PR DESCRIPTION
Add some more information to the group name configuration of the DNS challenge, so one understands that this has to also be configured in the helm chart values

Make group names more consistent, so that one can more easliy assume that those values correspond with each other