### PR TITLE
Make ZoneName optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Folders
 kubebuilder
+.vscode/
 .idea/
 # Binaries for programs and plugins
 *.exe

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ spec:
             solverName: hetzner
             config:
               secretName: hetzner-secret
-              zoneName: example.com
+              zoneName: example.com # (Optional): When not provided the Zone will searched in Hetzner API by recursion on full domain name
               apiUrl: https://dns.hetzner.com/api/v1
 ```
 

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func (c *hetznerDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error 
 	var recordId string
 	name := recordName(ch.ResolvedFQDN, config.ZoneName)
 	for i := len(records.Records) - 1; i >= 0; i-- {
-		if records.Records[i].Name == name {
+		if strings.EqualFold(records.Records[i].Name, name) {
 			recordId = records.Records[i].Id
 			break
 		}

--- a/main.go
+++ b/main.go
@@ -5,19 +5,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
 	"github.com/jetstack/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/acme/webhook/cmd"
 	"github.com/vadimkim/cert-manager-webhook-hetzner/internal"
-	"io"
-	"io/ioutil"
 	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
-	"net/http"
-	"os"
-	"regexp"
 )
 
 var GroupName = os.Getenv("GROUP_NAME")
@@ -190,6 +192,15 @@ func clientConfig(c *hetznerDNSProviderSolver, ch *v1alpha1.ChallengeRequest) (i
 		return config, fmt.Errorf("unable to get api-key from secret `%s/%s`; %v", secretName, ch.ResourceNamespace, err)
 	}
 
+	// Get ZoneName by api search if not provided by config
+	if config.ZoneName == "" {
+		foundZone, err := searchZoneName(config, ch.ResolvedZone)
+		if err!= nil {
+			return config, err
+		}
+		config.ZoneName = foundZone
+	}
+
 	return config, nil
 }
 
@@ -261,4 +272,18 @@ func searchZoneId(config internal.Config) (string, error) {
 		return "", fmt.Errorf("wrong number of zones in response %d must be exactly = 1", zones.Meta.Pagination.TotalEntries)
 	}
 	return zones.Zones[0].Id, nil
+}
+
+func searchZoneName(config internal.Config, searchZone string) (string, error) {
+	parts := strings.Split(searchZone, ".")
+	parts = parts[:len(parts)-1]
+	for i := 0; i <= len(parts) - 2; i++ {
+		config.ZoneName = strings.Join(parts[i:], ".")
+		zoneId, _ := searchZoneId(config)
+		if zoneId != "" {
+			klog.Infof("Found ID with ZoneName: %s", config.ZoneName)
+			return config.ZoneName, nil
+		}
+	}
+	return "", fmt.Errorf("unable to find hetzner dns zone with: %s", searchZone)
 }


### PR DESCRIPTION
I have many domains to manage with cert-manager but have to create an issuer for each of them, so i made the ZoneName parameter optional and implement an ZoneName search.

Also fixed an bug with cleanup not finding record if cert-manager provides it case-sensitiv.