### PR TITLE
Dont run as root

### DIFF
--- a/deploy/cert-manager-webhook-hetzner/Chart.yaml
+++ b/deploy/cert-manager-webhook-hetzner/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: Allow cert-manager to solve DNS challenges using Hetzner DNS API
 name: cert-manager-webhook-hetzner
-version: 1.1.0
+version: 1.1.1

--- a/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "cert-manager-webhook-hetzner.servingCertificate" . }}
+      securityContext:
+        runAsGroup: 1000
+        runAsUser: 1000
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/deploy/cert-manager-webhook-hetzner/values.yaml
+++ b/deploy/cert-manager-webhook-hetzner/values.yaml
@@ -14,7 +14,6 @@ certManager:
 
 image:
   repository: zmejg/cert-manager-webhook-hetzner
-  tag: latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Some things that I just found while installing it on a new cluster:
- We should not use latest as the tag for the image
- We should not run it as root (especially if its already using port 8443)