### PR TITLE
Remove alpha2 from apiVersion in cert example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ data:
 Finally you can create certificates, for example:
 
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: example-cert

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ helm uninstall --namespace cert-manager cert-manager-webhook-hetzner
 
 Create a `ClusterIssuer` or `Issuer` resource as following:
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging


### PR DESCRIPTION
while using the example to create a certificate kubectl aplly threw an error
`error: resource mapping not found for name: "example-cert" namespace: "cert-manager" from "cert-manager/issuers/test-hetzner-cert.yaml": no matches for kind "Certificate" in version "cert-manager.io/v1alpha2"
ensure CRDs are installed first`

removing the alpa2 resolved the issue