### PR TITLE
Allow to run with pod security 'restricted'

### DIFF
--- a/deploy/cert-manager-webhook-hetzner/Chart.yaml
+++ b/deploy/cert-manager-webhook-hetzner/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: Allow cert-manager to solve DNS challenges using Hetzner DNS API
 name: cert-manager-webhook-hetzner
-version: 1.1.1
+version: 1.1.2

--- a/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
               scheme: HTTPS
               path: /healthz
               port: https
+        {{- with .Values.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+        {{- end }}
           volumeMounts:
             - name: certs
               mountPath: /tls
@@ -56,9 +60,10 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "cert-manager-webhook-hetzner.servingCertificate" . }}
+    {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsGroup: 1000
-        runAsUser: 1000
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/deploy/cert-manager-webhook-hetzner/values.yaml
+++ b/deploy/cert-manager-webhook-hetzner/values.yaml
@@ -43,3 +43,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+podSecurityContext:
+  runAsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true


### PR DESCRIPTION
Addition to pull request #17.

Allows the pod to run with restritcted PodSecurity enabled (https://kubernetes.io/docs/concepts/security/pod-security-admission/).

```
Error creating: pods ... is forbidden:
violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "cert-manager-webhook-hetzner" must set securityContext.allowPrivilegeEscalation=false),
unrestricted capabilities (container "cert-manager-webhook-hetzner" must set securityContext.capabilities.drop=["ALL"]),
runAsNonRoot != true (pod or container "cert-manager-webhook-hetzner" must set securityContext.runAsNonRoot=true),
seccompProfile (pod or container "cert-manager-webhook-hetzner" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Thanks for the great project!