### PR TITLE
docs: details about the credential secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ spec:
 ### Credentials
 In order to access the Hetzner API, the webhook needs an API token.
 
-If you choose another name for the secret than `hetzner-secret`, ensure you modify the value of `secretName` in the `[Cluster]Issuer`.
+If you choose another name for the secret than `hetzner-secret`, you must install the chart with a modified `secretName` value. Policies ensure that no other secrets can be read by the webhook. Also modify the value of `secretName` in the `[Cluster]Issuer`.
 
 The secret for the example above will look like this:
 ```yaml
@@ -78,6 +78,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hetzner-secret
+  namespace: cert-manager
 type: Opaque
 data:
   api-key: your-key-base64-encoded


### PR DESCRIPTION
Mention that the credential secret name must be set when installing the helm chart. Also add the correct namespace to the example secret.