### PR TITLE
Fix duration format

### DIFF
--- a/deploy/cert-manager-webhook-hetzner/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-hetzner/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-hetzner.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "cert-manager-webhook-hetzner.selfSignedIssuer" . }}
   commonName: "ca.cert-manager-webhook-hetzner.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-hetzner.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "cert-manager-webhook-hetzner.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
Hi,

I have deployed the Helm Chart via Argo CD to a K8s 1.27 cluster. Argo CD always shows the Argo Application as being out of sync because cert manager seems to update the duration fields of the certificates.

The cert manager seems to parse the duration with the `time.ParseDuration` function (see https://github.com/cert-manager/cert-manager/blob/c56a2fb8a1b26d0381dc5bf7c31cde22c868ab7e/internal/apis/certmanager/types_certificate.go#L141) and the writes the result to the duation field of the certificates. Because the parsed duration string in the Helm Chart differs from the duration string returned by the function Argo CD shows the Argo Application as being out of sync.

To fix this issue I have updated the duration strings in the certificates to be equal to the duration strings returned by the function.