### PR TITLE
added capability to set corporate proxy

### DIFF
--- a/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
@@ -32,6 +32,18 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+            {{- with .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.no_proxy }}
+            - name: NO_PROXY
+              value: {{ . }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 8443

--- a/deploy/cert-manager-webhook-hetzner/values.yaml
+++ b/deploy/cert-manager-webhook-hetzner/values.yaml
@@ -44,6 +44,11 @@ tolerations: []
 
 affinity: {}
 
+# Use these variables to configure the HTTP_PROXY environment variables
+# http_proxy: "http://proxy:8080"
+# https_proxy: "https://proxy:8080"
+# no_proxy: 127.0.0.1,localhost
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
In some enterprise environments it is necessary to use a corporate proxy for web access, in this case for setting the DNS requests via Hetzner's API.

I have added the accordingly needed environment variables in the exact same way as cert-manager does it, in order to get a unified ux.