### PR TITLE
Add image build and deploy CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: build
+run-name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            vadimkim/cert-manager-webhook-hetzner
+            ghcr.io/vadimkim/cert-manager-webhook-hetzner
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY . .
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o webhook -ldflags '-w -extldflags "-static"' .
 
 FROM alpine:3.17
+LABEL maintainer="vadimkim <vadim@ant.ee>"
+LABEL org.opencontainers.image.source="https://github.com/vadimkim/cert-manager-webhook-hetzner"
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Hi @vadimkim,

As we talked in #39, this adds a GH action for building and deploying images to Docker Hub and GHCR. Alternatively we can also pull to quay.io as well.

For this to success, we need some action on your side before:

* Docker Hub, you need to setup here in GitHub the following secrets, 
  - As I could see, you dont have an account on docker hub right? Do we want to push to somewhere else? Or would you like to create one?
  - secrets.DOCKERHUB_USERNAME
  - secrets.DOCKERHUB_TOKEN
* GHCR, you need to setup a token so that the CI can push to
  -  secrets.GITHUB_TOKEN
  
And we can add quay.io later on if you wish.

Additionally, I added some labels to the Dockerfile, so that GH can like your created package correctly.

On releases, you need to tag the version with `git tag v1.3.0`, and do `git push --tags origin master`. This will create a tagged image automatically, otherwise it will be 'master'.

Best regards,

Mario