### PR TITLE
Automate helm release via GH Actions

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,2 @@
+MD013:
+  line_length: 600

--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,0 +1,11 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: master
+chart-dirs:
+  - deploy
+chart-repos:
+  - cert-manager-webhook-hetzner=https://vadimkim.github.io/cert-manager-webhook-hetzner
+helm-extra-args: --timeout 600s
+excluded-charts:
+additional-commands:
+  # - helm unittest --helm3 --strict --file unittests/*.yaml --file 'unittests/**/*.yaml' {{ .Path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - 'v*'
   pull_request:
+    paths:
+      - '**.go'
+      - 'Dockerfile'
+      - 'Makefile'
 
 jobs:
   build:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - '**.go'
+      - '.golangci.yml'
+      - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: read

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,44 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config .github/linters/ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --config .github/linters/ct.yaml
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.8.0
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --config .github/linters/ct.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,10 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'deploy/**'
+      - '.github/**'
 
 jobs:
   lint-test:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -43,6 +43,12 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.8.0
 
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+          kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
+          kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
+
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config .github/linters/ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+name: release-charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.12.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: deploy
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,31 @@
+name: Lint Code Base
+
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+on: pull_request
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: docker://github/super-linter:slim-v4
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: .github/linters
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BASH: false
+          VALIDATE_JSCPD: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
+          VALIDATE_PYTHON: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_YAML: false

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -3,7 +3,11 @@ name: Lint Code Base
 # Documentation:
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'deploy/**'
+      - '.github/**'
 
 jobs:
   build:

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -13,6 +13,15 @@ jobs:
   build:
     name: Lint Code Base
     runs-on: ubuntu-latest
+
+    ############################################
+    # Grant status permission for MULTI_STATUS #
+    ############################################
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/sync-readme.yaml
+++ b/.github/workflows/sync-readme.yaml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'README.md'
+
+jobs:
+  build:
+    permissions:
+      contents: write # for git push
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          cp -f README.md ${{ runner.temp }}/README.md
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - run: |
+          cp -f ${{ runner.temp }}/README.md .
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add README.md
+          git commit --signoff -m "Sync README from master"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ kubebuilder
 *.out
 
 # Ignore the built binary
-cert-manager-webhook-hetzner
+./cert-manager-webhook-hetzner

--- a/deploy/cert-manager-webhook-hetzner/Chart.yaml
+++ b/deploy/cert-manager-webhook-hetzner/Chart.yaml
@@ -1,5 +1,21 @@
-apiVersion: v1
-appVersion: "1.3.0"
-description: Allow cert-manager to solve DNS challenges using Hetzner DNS API
+apiVersion: v2
 name: cert-manager-webhook-hetzner
-version: 1.3.0
+version: 1.3.1
+appVersion: "1.3.0"
+kubeVersion: ">= 1.22.0-0"
+description: Allow cert-manager to solve DNS challenges using Hetzner DNS API
+home: https://github.com/vadimkim/cert-manager-webhook-hetzner
+icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo-small.png
+keywords:
+  - cert-manager
+  - hetzner
+  - kube-lego
+  - letsencrypt
+  - tls
+sources:
+  - https://github.com/vadimkim/cert-manager-webhook-hetzner
+maintainers:
+  - name: vadimkim
+    email: vadim@ant.ee
+annotations:
+  artifacthub.io/license: Apache-2.0

--- a/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-hetzner/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "cert-manager-webhook-hetzner.fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --tls-cert-file=/tls/tls.crt

--- a/deploy/cert-manager-webhook-hetzner/values.yaml
+++ b/deploy/cert-manager-webhook-hetzner/values.yaml
@@ -13,7 +13,10 @@ certManager:
   serviceAccountName: cert-manager
 
 image:
-  repository: zmejg/cert-manager-webhook-hetzner
+  registry: ghcr.io
+  repository: vadimkim/cert-manager-webhook-hetzner
+  # Overrides the image tag whose default is {{ printf "v%s" .Chart.AppVersion }}
+  tag: ""
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Hi @vadimkim,

This is related to the issue #58.

It uses the GitHub Container Registry instead of the github-pages branch itself to build the `index.yaml` file on `github-pages` branch. So that every helm release will be a new package there instead of a tarball.
It also changes the registry to use the new image from GHCR instead of the one from docker.io.

There are 4 new helm Actions jobs,

1. Lint Code Base:  [super-linter](https://github.com/super-linter/super-linter) which focus on YAML files.
1. Lint and Test Charts:  Lint and install this helm chart in a dynamically deployed kind cluster.
    NOTES:
      * From now on, it will be required that a new Chart version for every change in the chart, which is how all helm charts proceed.
      * This could be improved if we setup the webhook against a hetzner test account.
      *  I will create a separated issue for adding a simple helm test, which would be using the webhook. 
1. Sync: This will sync on master branch only the README.md file from the master branch to 'gh-pages'. If you want we could add a separated README.md file only for the helm chart.
1. Release: This will happen only after a PR merge, on master branch, and will deploy the helm chart to the GH Packages, and update the index.yaml file automatically. Of course, this is still untested.

Let me know if you are ok with this status, of if I should adjust something.

Thank you!

Mario