### PR TITLE
Adjust API group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Follow the [instructions](https://cert-manager.io/docs/installation/) using the 
 #### Using public helm chart
 ```bash
 helm repo add cert-manager-webhook-hetzner https://vadimkim.github.io/cert-manager-webhook-hetzner
-# Replace the groupName value with your desired domain
-helm install --namespace cert-manager cert-manager-webhook-hetzner cert-manager-webhook-hetzner/cert-manager-webhook-hetzner --set groupName=acme.yourdomain.tld
+helm install --namespace cert-manager cert-manager-webhook-hetzner cert-manager-webhook-hetzner/cert-manager-webhook-hetzner
 ```
 
 #### From local checkout
@@ -58,9 +57,8 @@ spec:
 
     solvers:
       - dns01:
-          webhook:
-            # This group needs to be configured when installing the helm package, otherwise the webhook won't have permission to create an ACME challenge for this API group.
-            groupName: acme.yourdomain.tld
+          webhook: 
+            groupName: hetzner.cert-mananger-webhook.noshoes.xyz
             solverName: hetzner
             config:
               secretName: hetzner-secret

--- a/deploy/cert-manager-webhook-hetzner/values.yaml
+++ b/deploy/cert-manager-webhook-hetzner/values.yaml
@@ -1,12 +1,6 @@
-# The GroupName here is used to identify your company or business unit that
-# created this webhook.
-# For example, this may be "acme.mycompany.com".
-# This name will need to be referenced in each Issuer's `webhook` stanza to
-# inform cert-manager of where to send ChallengePayload resources in order to
-# solve the DNS01 challenge.
-# This group name should be **unique**, hence using your own company's domain
-# here is recommended.FROM golang:1.14.0-alpine AS build_deps
-groupName: acme.yourdomain.tld
+# The kubernetes api group under which the webhook will be exposed. There is no need to
+# modify this value unless you are facing a collision in your api services.
+groupName: hetzner.cert-mananger-webhook.noshoes.xyz
 
 certManager:
   namespace: cert-manager


### PR DESCRIPTION
Hey there, thanks for implementing this! I'd like to address the following, admittedly rather common property of webhook-charts:

[This comment](https://github.com/cert-manager/webhook-example/blob/0dcb6537405096ec6415b5e81daa6568323e9833/deploy/example-webhook/values.yaml) in cert-manager's example-webhook repo is often misunderstood by webhook authors to mean that groupName needs to be configured for every installation and is therefore left at the default or some mock domain.

However, there is actually no need for chart-users to specify this value, instead the chart-authors should set it to something that is unique - i.e. a domain-name that they control.

Background:
Cert-manager webhook charts install an APIService resource, which is effectively describes an extension of the kubernetes api. This is done so one can outsource authentication and authorization to kubernetes api-server. After performing those, kubernetes will forward requests to the "regular" Service described in the APIService spec.
More details [here](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)

You can list the api-groups in your cluster by executing: kubeclt get apiservice.

The Kubernetes api is generally organized in so called "groups" to avoid naming-conflicts and as a general convention, extension authors choose a DNS-Domain they control as their api-group to ensure the groupName is globally unique.

Leaving the default or choosing some mock-domain like acme.yourdomain.tld actually has the opposite effect: You are more likely to cause a collision if chart-users fail to specify an api-group and install multiple webhooks.

I have chosen `hetzner.cert-mananger-webhook.noshoes.xyz` because I couldn't find a domain you likely own on your github profile. **It would be better to use a domain that you own, since you own the project.** If you don't own a domain or don't want to expose it, you can use the one from the PR, I own it. 